### PR TITLE
Cleanup package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "browser-sync": "^2.9.11",
     "gulp": "^3.9.0",
     "gulp-bower": "0.0.10",
-    "gulp-ignore": "^2.0.1",
-    "gulp-livereload": "^3.8.1",
     "gulp-serve": "^1.2.0",
     "rimraf": "^2.4.3"
   }


### PR DESCRIPTION
There's no need packages **gulp-livereload** and **gulp-ignore** which aren't been used.
